### PR TITLE
Skip dynamic imports when module name is string-interpolated

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function(src, options = {}) {
   walker.walk(src, function(node) {
     switch (node.type) {
       case 'Import':
-        if (node.parent && node.parent.type === 'CallExpression' && node.parent.arguments.length) {
+        if (node.parent && node.parent.type === 'CallExpression' && node.parent.arguments.length && node.parent.arguments[0].value) {
           dependencies.push(node.parent.arguments[0].value);
         }
         break;

--- a/test/test.js
+++ b/test/test.js
@@ -147,4 +147,9 @@ describe('detective-typescript', () => {
     assert(deps.length === 1);
     assert(deps[0] === 'foobar');
   })
+
+  it('does not count dynamic imports if module name is string-interpolated', () => {
+    const deps = detective('const filename = "ts.svg"; import(`./${filename}`);');
+    assert(deps.length === 0);
+  })
 });


### PR DESCRIPTION
Given the following scenario, in which a filename is passed as a prop to an `<Icon />` component...

```tsx
interface IconProps extends React.SVGProps<SVGSVGElement> {
  name: string;
}

const Icon: React.FC<IconProps> = ({ name, ...rest }): JSX.Element | null => {
  const ImportedIconRef = React.useRef<
    React.FC<React.SVGProps<SVGSVGElement>>
  >();
  const [loading, setLoading] = React.useState(false);

  React.useEffect((): void => {
    setLoading(true);
    const importIcon = async (): Promise<void> => {
      try {
        ImportedIconRef.current = (await import(`./${name}.svg`)).ReactComponent;
      } catch (err) {
        // Your own error handling logic, throwing error for the sake of
        // simplicity
        throw err;
      } finally {
        setLoading(false);
      }
    };
    importIcon();
  }, [name]);

  if (!loading && ImportedIconRef.current) {
    const { current: ImportedIcon } = ImportedIconRef;
    return <ImportedIcon {...rest} />;
  }

  return null;
};
```

*Example Code's Original Source*: https://stackoverflow.com/questions/61339259/how-to-dynamically-import-svg-and-render-it-inline

The value of `node.parent.arguments[0].value` on line [43](https://github.com/pahen/detective-typescript/blob/master/index.js#L43) is `undefined` for a dynamic import that is passed a module name that's string-interpolated. An `undefined` dependency would cause issues from libraries that rely on this library, such as [node-dependency-tree](https://github.com/dependents/node-dependency-tree), which uses [node-precinct](https://github.com/dependents/node-precinct) to retrieve a list of dependencies (node-precinct uses this library for TypeScript-related files).

Because it's unknown what exact SVG modules will be loaded via the dynamic import statement (since the module name is based on a prop), it's reasonable to not add it as a dependency of the `<Icon />` component's file.

Basically, this pull request checks if the value exists before adding it to the dependency list, similar to lines [46-64](https://github.com/pahen/detective-typescript/blob/master/index.js#L46-L64).