### PR TITLE
feat: identifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,10 +34,10 @@ module.exports = (src, options = {}) => {
     switch (node.type) {
       case 'ImportExpression':
         if (!options.skipAsyncImports && node.source && node.source.value) {
-          // Can't determine exact tokens for async imports.
-          dependencies.push(options.tokens ? {
+          // Can't determine exact identifiers for async imports.
+          dependencies.push(options.identifiers ? {
             path: node.source.value,
-            tokens: ['*']
+            identifiers: ['*']
           } : node.source.value);
         }
         break;
@@ -46,9 +46,9 @@ module.exports = (src, options = {}) => {
           break;
         }
         if (node.source && node.source.value) {
-          dependencies.push(options.tokens ? {
+          dependencies.push(options.identifiers ? {
             path: node.source.value,
-            tokens: node.specifiers.map(specifier =>
+            identifiers: node.specifiers.map(specifier =>
               specifier.type === 'ImportDefaultSpecifier' ? 'default' : specifier.imported.name
             )
           } : node.source.value);
@@ -56,34 +56,34 @@ module.exports = (src, options = {}) => {
         break;
       case 'ExportNamedDeclaration':
         if (node.source && node.source.value) {
-          dependencies.push(options.tokens ? {
+          dependencies.push(options.identifiers ? {
             path: node.source.value,
-            tokens: node.specifiers.map(specifier => specifier.exported.name)
+            identifiers: node.specifiers.map(specifier => specifier.exported.name)
           } : node.source.value);
         }
         break;
       case 'ExportAllDeclaration':
         if (node.source && node.source.value) {
-          // Can't determine exact tokens for re-exports.
-          dependencies.push(options.tokens ? {
+          // Can't determine exact identifiers for re-exports.
+          dependencies.push(options.identifiers ? {
             path: node.source.value,
-            tokens: ['*']
+            identifiers: ['*']
           } : node.source.value);
         }
         break;
       case 'TSExternalModuleReference':
         if (node.expression && node.expression.value) {
-          dependencies.push(options.tokens ? {
+          dependencies.push(options.identifiers ? {
             path: node.expression.value,
-            tokens: ['*']
+            identifiers: ['*']
           } : node.expression.value);
         }
         break;
       case 'TSImportType':
         if (!skipTypeImports && node.parameter.type === 'TSLiteralType') {
-          dependencies.push(options.tokens ? {
+          dependencies.push(options.identifiers ? {
             path: node.parameter.literal.value,
-            tokens: ['*']
+            identifiers: ['*']
           } : node.parameter.literal.value);
         }
         break;
@@ -97,18 +97,18 @@ module.exports = (src, options = {}) => {
         if (types.isPlainRequire(node)) {
           const result = extractDependencyFromRequire(node);
           if (result) {
-            // Can't determine exact tokens for require.
-            dependencies.push(options.tokens ? {
+            // Can't determine exact identifiers for require.
+            dependencies.push(options.identifiers ? {
               path: result,
-              tokens: ['*']
+              identifiers: ['*']
             } : result);
           }
         } else if (types.isMainScopedRequire(node)) {
           const result = extractDependencyFromMainRequire(node);
-          // Can't determine exact tokens for require.
-          dependencies.push(options.tokens ? {
+          // Can't determine exact identifiers for require.
+          dependencies.push(options.identifiers ? {
             path: result,
-            tokens: ['*']
+            identifiers: ['*']
           } : result);
         }
 

--- a/index.js
+++ b/index.js
@@ -66,12 +66,12 @@ module.exports = (src, options = {}) => {
         break;
       case 'TSExternalModuleReference':
         if (node.expression && node.expression.value) {
-          dependencies.push(options.tokens ? [node.expression.value, []] : node.expression.value);
+          dependencies.push(options.tokens ? [node.expression.value, ['*']] : node.expression.value);
         }
         break;
       case 'TSImportType':
         if (!skipTypeImports && node.parameter.type === 'TSLiteralType') {
-          dependencies.push(options.tokens ? [node.parameter.literal.value, []] : node.parameter.literal.value);
+          dependencies.push(options.tokens ? [node.parameter.literal.value, ['*']] : node.parameter.literal.value);
         }
         break;
       case 'CallExpression':

--- a/index.js
+++ b/index.js
@@ -35,7 +35,10 @@ module.exports = (src, options = {}) => {
       case 'ImportExpression':
         if (!options.skipAsyncImports && node.source && node.source.value) {
           // Can't determine exact tokens for async imports.
-          dependencies.push(options.tokens ? [node.source.value, ['*']] : node.source.value);
+          dependencies.push(options.tokens ? {
+            path: node.source.value,
+            tokens: ['*']
+          } : node.source.value);
         }
         break;
       case 'ImportDeclaration':
@@ -43,35 +46,46 @@ module.exports = (src, options = {}) => {
           break;
         }
         if (node.source && node.source.value) {
-          dependencies.push(options.tokens ? [
-            node.source.value,
-            node.specifiers.map(specifier =>
+          dependencies.push(options.tokens ? {
+            path: node.source.value,
+            tokens: node.specifiers.map(specifier =>
               specifier.type === 'ImportDefaultSpecifier' ? 'default' : specifier.imported.name
             )
-          ] : node.source.value);
+          } : node.source.value);
         }
         break;
       case 'ExportNamedDeclaration':
         if (node.source && node.source.value) {
-          dependencies.push(options.tokens ? [node.source.value,
-            node.specifiers.map(specifier => specifier.exported.name)
-          ] : node.source.value);
+          dependencies.push(options.tokens ? {
+            path: node.source.value,
+            tokens: node.specifiers.map(specifier => specifier.exported.name)
+          } : node.source.value);
         }
         break;
       case 'ExportAllDeclaration':
         if (node.source && node.source.value) {
           // Can't determine exact tokens for re-exports.
-          dependencies.push(options.tokens ? [node.source.value, ['*']] : node.source.value);
+          dependencies.push(options.tokens ? {
+            path: node.source.value,
+            tokens: ['*']
+          } : node.source.value);
         }
         break;
       case 'TSExternalModuleReference':
         if (node.expression && node.expression.value) {
-          dependencies.push(options.tokens ? [node.expression.value, ['*']] : node.expression.value);
+          dependencies.push(options.tokens ? {
+            path: node.expression.value,
+            tokens: ['*']
+          } : node.expression.value);
         }
         break;
       case 'TSImportType':
         if (!skipTypeImports && node.parameter.type === 'TSLiteralType') {
-          dependencies.push(options.tokens ? [node.parameter.literal.value, ['*']] : node.parameter.literal.value);
+          dependencies.push(options.tokens ?
+            {
+              path: node.parameter.literal.value,
+              tokens: ['*']
+            } : node.parameter.literal.value);
         }
         break;
       case 'CallExpression':
@@ -85,12 +99,18 @@ module.exports = (src, options = {}) => {
           const result = extractDependencyFromRequire(node);
           if (result) {
             // Can't determine exact tokens for require.
-            dependencies.push(options.tokens ? [result, ['*']] : result);
+            dependencies.push(options.tokens ? {
+              path: result,
+              tokens: ['*']
+            } : result);
           }
         } else if (types.isMainScopedRequire(node)) {
           const result = extractDependencyFromMainRequire(node);
           // Can't determine exact tokens for require.
-          dependencies.push(options.tokens ? [result, ['*']] : result);
+          dependencies.push(options.tokens ? {
+            path: result,
+            tokens: ['*']
+          } : result);
         }
 
         break;

--- a/index.js
+++ b/index.js
@@ -81,11 +81,10 @@ module.exports = (src, options = {}) => {
         break;
       case 'TSImportType':
         if (!skipTypeImports && node.parameter.type === 'TSLiteralType') {
-          dependencies.push(options.tokens ?
-            {
-              path: node.parameter.literal.value,
-              tokens: ['*']
-            } : node.parameter.literal.value);
+          dependencies.push(options.tokens ? {
+            path: node.parameter.literal.value,
+            tokens: ['*']
+          } : node.parameter.literal.value);
         }
         break;
       case 'CallExpression':

--- a/index.js
+++ b/index.js
@@ -84,11 +84,13 @@ module.exports = (src, options = {}) => {
         if (types.isPlainRequire(node)) {
           const result = extractDependencyFromRequire(node);
           if (result) {
-            dependencies.push(options.tokens ? [result, []] : result);
+            // Can't determine exact tokens for require.
+            dependencies.push(options.tokens ? [result, ['*']] : result);
           }
         } else if (types.isMainScopedRequire(node)) {
           const result = extractDependencyFromMainRequire(node);
-          dependencies.push(options.tokens ? [result, []] : result);
+          // Can't determine exact tokens for require.
+          dependencies.push(options.tokens ? [result, ['*']] : result);
         }
 
         break;

--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ module.exports = (src, options = {}) => {
         if (node.source && node.source.value) {
           dependencies.push(options.tokens ? [
             node.source.value,
-            node.specifiers.map(specifier => specifier.imported.name)
+            node.specifiers.map(specifier =>
+              specifier.type === 'ImportDefaultSpecifier' ? 'default' : specifier.imported.name
+            )
           ] : node.source.value);
         }
         break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "detective-typescript",
       "version": "9.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "detective-typescript",
       "version": "9.0.0",
       "license": "MIT",
       "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -37,12 +37,12 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'mylib');
   });
 
-  it('retrieves the dependencies of modules with tokens', () => {
+  it('retrieves the dependencies of modules with identifiers', () => {
     const deps = detective('import {foo, bar} from "mylib";', {
-      tokens: true
+      identifiers: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], { path: 'mylib', tokens: ['foo', 'bar'] });
+    assert.deepEqual(deps[0], { path: 'mylib', identifiers: ['foo', 'bar'] });
   });
 
   it('retrieves the re-export dependencies of modules', () => {
@@ -51,12 +51,12 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'mylib');
   });
 
-  it('retrieves the re-export dependencies of modules with tokens', () => {
+  it('retrieves the re-export dependencies of modules with identifiers', () => {
     const deps = detective('export {foo, bar} from "mylib";', {
-      tokens: true
+      identifiers: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], { path: 'mylib', tokens: ['foo', 'bar'] });
+    assert.deepEqual(deps[0], { path: 'mylib', identifiers: ['foo', 'bar'] });
   });
 
   it('retrieves the re-export * dependencies of modules', () => {
@@ -65,12 +65,12 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'mylib');
   });
 
-  it('retrieves the re-export * dependencies of modules with tokens', () => {
+  it('retrieves the re-export * dependencies of modules with identifiers', () => {
     const deps = detective('export * from "mylib";', {
-      tokens: true
+      identifiers: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], { path: 'mylib', tokens: ['*'] });
+    assert.deepEqual(deps[0], { path: 'mylib', identifiers: ['*'] });
   });
 
   it('handles multiple imports', () => {
@@ -86,12 +86,12 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
-  it('handles default imports with tokens', () => {
+  it('handles default imports with identifiers', () => {
     const deps = detective('import foo from "foo";', {
-      tokens: true
+      identifiers: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], { path: 'foo', tokens: ['default'] });
+    assert.deepEqual(deps[0], { path: 'foo', identifiers: ['default'] });
   });
 
   it('handles dynamic imports', () => {
@@ -100,12 +100,12 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
-  it('handles dynamic imports with tokens', () => {
+  it('handles dynamic imports with identifiers', () => {
     const deps = detective('import("foo");', {
-      tokens: true
+      identifiers: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], { path: 'foo', tokens: ['*'] });
+    assert.deepEqual(deps[0], { path: 'foo', identifiers: ['*'] });
   });
 
   it('handles async imports', () => {
@@ -114,12 +114,12 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
-  it('handles async imports with tokens', () => {
+  it('handles async imports with identifiers', () => {
     const deps = detective('import("foo");', {
-      tokens: true
+      identifiers: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], { path: 'foo', tokens: ['*'] });
+    assert.deepEqual(deps[0], { path: 'foo', identifiers: ['*'] });
   });
 
   it('skips async imports when using skipAsyncImports', () => {
@@ -191,12 +191,12 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
-  it('parses out type annotation imports with tokens', () => {
+  it('parses out type annotation imports with identifiers', () => {
     const deps = detective('const x: typeof import("foo") = 0;', {
-      tokens: true
+      identifiers: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], { path: 'foo', tokens: ['*'] });
+    assert.deepEqual(deps[0], { path: 'foo', identifiers: ['*'] });
   });
 
   it('does not count type annotation imports if the skipTypeImports option is enabled', () => {
@@ -210,12 +210,12 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
-  it('parses out TypeScript >=3.8 type imports with tokens', () => {
+  it('parses out TypeScript >=3.8 type imports with identifiers', () => {
     const deps = detective('import type { Foo } from "foo"', {
-      tokens: true
+      identifiers: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], { path: 'foo', tokens: ['Foo'] });
+    assert.deepEqual(deps[0], { path: 'foo', identifiers: ['Foo'] });
   });
 
   it('does not count TypeScript >=3.8 type imports if the skipTypeImports option is enabled', () => {
@@ -229,12 +229,12 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foobar');
   });
 
-  it('supports CJS when mixedImports is true with tokens', () => {
+  it('supports CJS when mixedImports is true with identifiers', () => {
     const deps = detective('const foo = require("foobar")', {
       mixedImports: true,
-      tokens: true
+      identifiers: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], { path: 'foobar', tokens: ['*'] });
+    assert.deepEqual(deps[0], { path: 'foobar', identifiers: ['*'] });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -31,13 +31,13 @@ describe('detective-typescript', () => {
     assert.equal(deps.length, 0);
   });
 
-  it('handles imports without identifiers', () => {
+  it('handles identifier-free imports', () => {
     const deps = detective('import "mylib";');
     assert.equal(deps.length, 1);
     assert.equal(deps[0], 'mylib');
   });
 
-  it('handles imports without identifiers', () => {
+  it('handles identifier-free imports asking for identifiers', () => {
     const deps = detective('import "mylib";', {
       identifiers: true
     });

--- a/test/test.js
+++ b/test/test.js
@@ -65,6 +65,14 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'mylib');
   });
 
+  it('retrieves the re-export * dependencies of modules with tokens', () => {
+    const deps = detective('export * from "mylib";', {
+      tokens: true
+    });
+    assert.equal(deps.length, 1);
+    assert.deepEqual(deps[0], ['mylib', ['*']]);
+  });
+
   it('handles multiple imports', () => {
     const deps = detective('import {foo, bar} from "mylib";\nimport "mylib2"');
     assert.equal(deps.length,  2);
@@ -76,6 +84,14 @@ describe('detective-typescript', () => {
     const deps = detective('import foo from "foo";');
     assert.equal(deps.length, 1);
     assert.equal(deps[0], 'foo');
+  });
+
+  it('handles default imports with tokens', () => {
+    const deps = detective('import foo from "foo";', {
+      tokens: true
+    });
+    assert.equal(deps.length, 1);
+    assert.deepEqual(deps[0], ['foo', ['default']]);
   });
 
   it('handles dynamic imports', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,6 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'mylib');
   });
 
-
   it('handles imports without identifiers', () => {
     const deps = detective('import "mylib";', {
       identifiers: true

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,21 @@ describe('detective-typescript', () => {
     assert.equal(deps.length, 0);
   });
 
+  it('handles imports without identifiers', () => {
+    const deps = detective('import "mylib";');
+    assert.equal(deps.length, 1);
+    assert.equal(deps[0], 'mylib');
+  });
+
+
+  it('handles imports without identifiers', () => {
+    const deps = detective('import "mylib";', {
+      identifiers: true
+    });
+    assert.equal(deps.length, 1);
+    assert.deepEqual(deps[0], { path: 'mylib', identifiers: [] });
+  });
+
   it('retrieves the dependencies of modules', () => {
     const deps = detective('import {foo, bar} from "mylib";');
     assert.equal(deps.length, 1);

--- a/test/test.js
+++ b/test/test.js
@@ -51,7 +51,7 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'mylib');
   });
 
-  it('retrieves the dependencies of modules with identifiers', () => {
+  it('retrieves the dependencies of modules asking for identifiers', () => {
     const deps = detective('import {foo, bar} from "mylib";', {
       identifiers: true
     });
@@ -65,7 +65,7 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'mylib');
   });
 
-  it('retrieves the re-export dependencies of modules with identifiers', () => {
+  it('retrieves the re-export dependencies of modules asking for identifiers', () => {
     const deps = detective('export {foo, bar} from "mylib";', {
       identifiers: true
     });
@@ -79,7 +79,7 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'mylib');
   });
 
-  it('retrieves the re-export * dependencies of modules with identifiers', () => {
+  it('retrieves the re-export * dependencies of modules asking for identifiers', () => {
     const deps = detective('export * from "mylib";', {
       identifiers: true
     });
@@ -100,7 +100,7 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
-  it('handles default imports with identifiers', () => {
+  it('handles default imports asking for identifiers', () => {
     const deps = detective('import foo from "foo";', {
       identifiers: true
     });
@@ -114,7 +114,7 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
-  it('handles dynamic imports with identifiers', () => {
+  it('handles dynamic imports asking for identifiers', () => {
     const deps = detective('import("foo");', {
       identifiers: true
     });
@@ -128,7 +128,7 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
-  it('handles async imports with identifiers', () => {
+  it('handles async imports asking for identifiers', () => {
     const deps = detective('import("foo");', {
       identifiers: true
     });
@@ -205,7 +205,7 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
-  it('parses out type annotation imports with identifiers', () => {
+  it('parses out type annotation imports asking for identifiers', () => {
     const deps = detective('const x: typeof import("foo") = 0;', {
       identifiers: true
     });
@@ -224,7 +224,7 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
-  it('parses out TypeScript >=3.8 type imports with identifiers', () => {
+  it('parses out TypeScript >=3.8 type imports asking for identifiers', () => {
     const deps = detective('import type { Foo } from "foo"', {
       identifiers: true
     });
@@ -243,7 +243,7 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foobar');
   });
 
-  it('supports CJS when mixedImports is true with identifiers', () => {
+  it('supports CJS when mixedImports is true asking for identifiers', () => {
     const deps = detective('const foo = require("foobar")', {
       mixedImports: true,
       identifiers: true

--- a/test/test.js
+++ b/test/test.js
@@ -100,10 +100,26 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
+  it('handles dynamic imports with tokens', () => {
+    const deps = detective('import("foo");', {
+      tokens: true
+    });
+    assert.equal(deps.length, 1);
+    assert.deepEqual(deps[0], ['foo', ['*']]);
+  });
+
   it('handles async imports', () => {
     const deps = detective('() => import("foo");');
     assert.equal(deps.length, 1);
     assert.equal(deps[0], 'foo');
+  });
+
+  it('handles async imports with tokens', () => {
+    const deps = detective('import("foo");', {
+      tokens: true
+    });
+    assert.equal(deps.length, 1);
+    assert.deepEqual(deps[0], ['foo', ['*']]);
   });
 
   it('skips async imports when using skipAsyncImports', () => {
@@ -195,5 +211,14 @@ describe('detective-typescript', () => {
     const deps = detective('const foo = require("foobar")', { mixedImports: true });
     assert.equal(deps.length, 1);
     assert.equal(deps[0], 'foobar');
+  });
+
+  it('supports CJS when mixedImports is true with tokens', () => {
+    const deps = detective('const foo = require("foobar")', {
+      mixedImports: true,
+      tokens: true
+    });
+    assert.equal(deps.length, 1);
+    assert.deepEqual(deps[0], ['foobar', ['*']]);
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -191,6 +191,14 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'foo');
   });
 
+  it('parses out type annotation imports with tokens', () => {
+    const deps = detective('const x: typeof import("foo") = 0;', {
+      tokens: true
+    });
+    assert.equal(deps.length, 1);
+    assert.deepEqual(deps[0], ['foo', ['*']]);
+  });
+
   it('does not count type annotation imports if the skipTypeImports option is enabled', () => {
     const deps = detective('const x: typeof import("foo") = 0;', {skipTypeImports: true});
     assert.equal(deps.length,  0);
@@ -200,6 +208,14 @@ describe('detective-typescript', () => {
     const deps = detective('import type { Foo } from "foo"');
     assert.equal(deps.length, 1);
     assert.equal(deps[0], 'foo');
+  });
+
+  it('parses out TypeScript >=3.8 type imports with tokens', () => {
+    const deps = detective('import type { Foo } from "foo"', {
+      tokens: true
+    });
+    assert.equal(deps.length, 1);
+    assert.deepEqual(deps[0], ['foo', ['Foo']]);
   });
 
   it('does not count TypeScript >=3.8 type imports if the skipTypeImports option is enabled', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -42,7 +42,7 @@ describe('detective-typescript', () => {
       tokens: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], ['mylib', ['foo', 'bar']]);
+    assert.deepEqual(deps[0], { path: 'mylib', tokens: ['foo', 'bar'] });
   });
 
   it('retrieves the re-export dependencies of modules', () => {
@@ -56,7 +56,7 @@ describe('detective-typescript', () => {
       tokens: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], ['mylib', ['foo', 'bar']]);
+    assert.deepEqual(deps[0], { path: 'mylib', tokens: ['foo', 'bar'] });
   });
 
   it('retrieves the re-export * dependencies of modules', () => {
@@ -70,7 +70,7 @@ describe('detective-typescript', () => {
       tokens: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], ['mylib', ['*']]);
+    assert.deepEqual(deps[0], { path: 'mylib', tokens: ['*'] });
   });
 
   it('handles multiple imports', () => {
@@ -91,7 +91,7 @@ describe('detective-typescript', () => {
       tokens: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], ['foo', ['default']]);
+    assert.deepEqual(deps[0], { path: 'foo', tokens: ['default'] });
   });
 
   it('handles dynamic imports', () => {
@@ -105,7 +105,7 @@ describe('detective-typescript', () => {
       tokens: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], ['foo', ['*']]);
+    assert.deepEqual(deps[0], { path: 'foo', tokens: ['*'] });
   });
 
   it('handles async imports', () => {
@@ -119,7 +119,7 @@ describe('detective-typescript', () => {
       tokens: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], ['foo', ['*']]);
+    assert.deepEqual(deps[0], { path: 'foo', tokens: ['*'] });
   });
 
   it('skips async imports when using skipAsyncImports', () => {
@@ -196,7 +196,7 @@ describe('detective-typescript', () => {
       tokens: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], ['foo', ['*']]);
+    assert.deepEqual(deps[0], { path: 'foo', tokens: ['*'] });
   });
 
   it('does not count type annotation imports if the skipTypeImports option is enabled', () => {
@@ -215,7 +215,7 @@ describe('detective-typescript', () => {
       tokens: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], ['foo', ['Foo']]);
+    assert.deepEqual(deps[0], { path: 'foo', tokens: ['Foo'] });
   });
 
   it('does not count TypeScript >=3.8 type imports if the skipTypeImports option is enabled', () => {
@@ -235,6 +235,6 @@ describe('detective-typescript', () => {
       tokens: true
     });
     assert.equal(deps.length, 1);
-    assert.deepEqual(deps[0], ['foobar', ['*']]);
+    assert.deepEqual(deps[0], { path: 'foobar', tokens: ['*'] });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -37,10 +37,26 @@ describe('detective-typescript', () => {
     assert.equal(deps[0], 'mylib');
   });
 
+  it('retrieves the dependencies of modules with tokens', () => {
+    const deps = detective('import {foo, bar} from "mylib";', {
+      tokens: true
+    });
+    assert.equal(deps.length, 1);
+    assert.deepEqual(deps[0], ['mylib', ['foo', 'bar']]);
+  });
+
   it('retrieves the re-export dependencies of modules', () => {
     const deps = detective('export {foo, bar} from "mylib";');
     assert.equal(deps.length, 1);
     assert.equal(deps[0], 'mylib');
+  });
+
+  it('retrieves the re-export dependencies of modules with tokens', () => {
+    const deps = detective('export {foo, bar} from "mylib";', {
+      tokens: true
+    });
+    assert.equal(deps.length, 1);
+    assert.deepEqual(deps[0], ['mylib', ['foo', 'bar']]);
   });
 
   it('retrieves the re-export * dependencies of modules', () => {


### PR DESCRIPTION
Supports https://github.com/dependents/node-dependency-tree/issues/147.

Support passing an option `identifiers: true` to return imported identifiers in addition to paths.

For named imports or re-exports like this:

```ts
import { one, two } from 'whatever';

// or

export { one, two } from 'whatever';
```

The result will then look like this:
```js
[
  { path: 'whatever', identifiers: ['one', 'two'] }
]
```
instead of just this:
```js
['whatever']
```

In the case of default exports like:

```ts
import foo from 'whatever';
```

We'll return:
```ts
{ path: 'whatever', identifiers: ['default'] }
```

In cases of import or re-export all, or dynamic imports, or where we otherwise just can't determine, like:

```ts
import * from 'whatever';

// or

export * from 'whatever';

// or

import('whatever').then(/* ... */);
```

We'll return:
```ts
{ path: 'whatever', identifiers: ['*'] }
```

