### PR TITLE
Add supports for ignore named imports and exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = (src, options = {}) => {
       }
 
       case 'ImportDeclaration': {
-        if (skipTypeImports && node.importKind === 'type') {
+        if (skipTypeImports && isTypeImports(node)) {
           break;
         }
 
@@ -61,6 +61,10 @@ module.exports = (src, options = {}) => {
 
       case 'ExportNamedDeclaration':
       case 'ExportAllDeclaration': {
+        if (skipTypeImports && isTypeExports(node)) {
+          break;
+        }
+
         if (node.source?.value) {
           dependencies.push(node.source.value);
         }
@@ -131,4 +135,24 @@ function extractDependencyFromRequire(node) {
 
 function extractDependencyFromMainRequire(node) {
   return node.arguments[0].value;
+}
+
+function isTypeImports(node) {
+  if (node.importKind === 'type') {
+    return true;
+  }
+
+  if (node.specifiers?.length && node.specifiers?.every(n => n.importKind === 'type')) {
+    return true;
+  }
+}
+
+function isTypeExports(node) {
+  if (node.exportKind === 'type') {
+    return true;
+  }
+
+  if (node.specifiers?.length && node.specifiers?.every(n => n.exportKind === 'type')) {
+    return true;
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -145,6 +145,36 @@ describe('detective-typescript', () => {
     assert.equal(deps.length, 0);
   });
 
+  it('does not count TypeScript named type imports if the skipTypeImports option is enabled', () => {
+    const fixture = 'import { type Foo } from "foo"';
+    const deps = detective(fixture, { skipTypeImports: true });
+    assert.equal(deps.length, 0);
+
+    // If not all the named imports are type imports, then it still counts as a dep.
+    const fixture2 = 'import { type Foo, Bar } from "foo"';
+    const deps2 = detective(fixture2, { skipTypeImports: true });
+    assert.equal(deps2.length, 1);
+    assert.equal(deps2[0], 'foo');
+  });
+
+  it('does not count TypeScript type exports if the skipTypeImports option is enabled', () => {
+    const fixture = 'export type { Foo } from "foo"';
+    const deps = detective(fixture, { skipTypeImports: true });
+    assert.equal(deps.length, 0);
+  });
+
+  it('does not count TypeScript named exports if the skipTypeImports option is enabled', () => {
+    const fixture = 'export { type Foo } from "foo"';
+    const deps = detective(fixture, { skipTypeImports: true });
+    assert.equal(deps.length, 0);
+
+    // If not all the named exports are type exports, then it still counts as a dep.
+    const fixture2 = 'export { type Foo, Bar } from "foo"';
+    const deps2 = detective(fixture2, { skipTypeImports: true });
+    assert.equal(deps2.length, 1);
+    assert.equal(deps2[0], 'foo');
+  });
+
   it('supports CJS when mixedImports is true', () => {
     const fixture = 'const foo = require("foobar")';
     const deps = detective(fixture, { mixedImports: true });


### PR DESCRIPTION
When the `skipTypeImports` option is enabled, only ignoring type imports is not sufficient. With TypeScript 4.5, it also supports named type imports and named type exports.